### PR TITLE
Use encoding='utf-8' when opening datafiles

### DIFF
--- a/mupub/commands/init.py
+++ b/mupub/commands/init.py
@@ -117,7 +117,7 @@ def _update_tracker(conn):
 def _db_update(conn, datadir, target, table_name=None):
     if not table_name:
         table_name = target+'s'
-    with open(os.path.join(datadir, table_name+'.dat'), 'r') as infile:
+    with open(os.path.join(datadir, table_name+'.dat'), mode='r', encoding='utf-8') as infile:
         cursor = conn.cursor()
         sql_insert = _INSERT.format(table_name, target)
         for line in infile:


### PR DESCRIPTION
I have been experimenting with running mupub in docker for building on AWS codebuild.
The default environment within docker results in python attempting to open datafiles (composers.dat etc.) as ascii, which fails.
Fixing the encoding in the open command is consistent with other open commands within mupub.